### PR TITLE
12058 - Deprecate wildlink-js-client

### DIFF
--- a/.github/workflows/actions-publish.yml
+++ b/.github/workflows/actions-publish.yml
@@ -3,30 +3,46 @@ on:
   push:
     branches:
       master
+    paths-ignore:
+      - ".github/**"
 jobs:
   push:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Collect Secrets
+        id: op-load-secret
+        uses: 1password/load-secrets-action@v2
+        with:
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SA_NPM_TOOLING }}
+          NPM_TOKEN: op://p7ggbiqtkwsqpwbfxyslrgl46u/tctdu656f2fh2pawg4g34qxbnq/credential
+
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '14.19.3'
           registry-url: 'https://registry.npmjs.org'
+
       - name: Cache Node Modules
         id: cache-node-modules
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: node_modules
           key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
+
       - name: Install Dependencies
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: |
           yarn install --freeze-lockfile
+
       - name: Run tests
         run: CI=true yarn test
+
       - name: Publish to NPM
         run: npm publish
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ env.NPM_TOKEN }}

--- a/.github/workflows/actions-test.yml
+++ b/.github/workflows/actions-test.yml
@@ -7,10 +7,10 @@ jobs:
       image: node:14.19.3
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Cache Node Modules
         id: cache-node-modules
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: node_modules
           key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wildlink-js-client",
   "version": "3.6.2",
-  "description": "A simple JavaScript client library for the Wildlink API (learn more at https://www.wildlink.me/)",
+  "description": "A simple JavaScript client library for the Wildlink API (DEPRECATED)",
   "homepage": "https://www.wildlink.me",
   "repository": "https://github.com/wildlink/wildlink-js-client.git",
   "author": "Wildfire Systems, Inc.",


### PR DESCRIPTION
Previous try on this didn't publish, so adjust it to our new process. Ignore changes to the .github directory for publishing and update the actions versions.