### PR TITLE
ubuntu 20.04 LTS is going EOL, update workflows to ubuntu-latest

### DIFF
--- a/.github/workflows/actions-publish.yml
+++ b/.github/workflows/actions-publish.yml
@@ -7,7 +7,7 @@ on:
       - ".github/**"
 jobs:
   push:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/actions-test.yml
+++ b/.github/workflows/actions-test.yml
@@ -2,7 +2,7 @@ name: GitHub Actions CI
 on: [push]
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container:
       image: node:14.19.3
     steps:


### PR DESCRIPTION
<!-- 
  🚨 Please fill out this template with the appropriate information for your pull request. 🚨
  Comments will not appear in the output on GitHub. 🥷
-->

## Ticket Link 📇
[❗Get off Ubuntu 20.04 in Github Actions❗](https://linear.app/wildfire-systems/project/get-off-ubuntu-2004-in-github-actions-1ccaa06626ae/overview)

## Description 📝
<!--
  Please list a summary of the changes/which issue was fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
ubuntu 20.04 LTS is going EOL, update workflows to ubuntu-latest
https://linear.app/wildfire-systems/project/get-off-ubuntu-2004-in-github-actions-1ccaa06626ae/overview

## Self-Check 🔍
<!--
  Each of these items must be checked off before your pull request is eligible for merge.
  For items that do not apply, please add a note with justification and check it off.
-->
For any list item that is not applicable, please include an explanation:
- [x] Commits are squashed to a limit of 1